### PR TITLE
use std::time & bump to 0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulse"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Colin Sherratt <colin.sherratt@gmail.com>"]
 license = "Apache-2.0"
 description = "A library for async wake signals"
@@ -8,7 +8,6 @@ homepage = "https://github.com/csherratt/pulse"
 
 [dependencies]
 atom = "0.3"
-time = "0.1"
 
 [features]
 default = []


### PR DESCRIPTION
the crate time is deprecated, so I think it is better to use std::time instead.